### PR TITLE
Add the XML Validator library to the Data category of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The Robot Framework Foundation is a non-profit organization that supports the de
   - [JSON Schema Library](https://github.com/jstaffans/robotframework-jsonschemalibrary) JSON Schema validation library for Robot Framework.
   - [JSON Validator](https://pypi.org/project/robotframework-jsonvalidator/) JSON validation based on JSONSchema, JSONPath, JSONSelect.
   - [String Format](https://pypi.org/project/robotframework-stringformat/) String formatting.
+  - [XML Validator](https://pypi.org/project/robotframework-xmlvalidator/) A Robot Framework library for validating XML files against XSD schemas.
 
 ### Database
   - [Cassandracql Library](https://pypi.org/project/robotframework-cassandracqllibrary/) Execute CQL statements in Cassandra Database.


### PR DESCRIPTION
This pull request adds a new Robot Framework library to the 'Data' category/list of the README.md.

Name: Xml Validator

Description: A Robot Framework library for validating XML files against XSD schemas.

Link: https://pypi.org/project/robotframework-xmlvalidator/

Source: https://github.com/MichaelHallik/robotframework-xmlvalidator