### PR TITLE
Add robotframework-falsegreen to Development and Editing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ The Robot Framework Foundation is a non-profit organization that supports the de
 - [Robocop](https://robocop.dev/stable/) - Static code analysis tool and formatting with configurable rules.
 - [Find Unused](https://github.com/Lakitna/robotframework-find-unused) - CLI tool to find unused keywords, arguments, returns, and global variables across folders.
 - [RobotFramework Recorder](https://chromewebstore.google.com/detail/robotframework-recorder/jgimecbadohdchfdpajoegnbejfkndpg) - Chrome extension for recording Robot Framework steps for Selenium and Browser libraries.
+- [robotframework-falsegreen](https://github.com/vinicq/robotframework-falsegreen) - Static scan that finds tests passing green without verifying anything (no oracle, swallowed failures, always-true checks), via the official robot.api.
 
 ### Reporting Tools
 


### PR DESCRIPTION
Adds one entry to the **Tools -> Development and Editing Tools** section for [robotframework-falsegreen](https://github.com/vinicq/robotframework-falsegreen).

It is a static scanner that finds Robot Framework tests passing green without verifying anything: no oracle / verification keyword, swallowed failures, and always-true checks. It runs over suite source via the official `robot.api`.

- Repo: https://github.com/vinicq/robotframework-falsegreen
- Install: `pip install robotframework-falsegreen`, CLI `rffalsegreen` (PyPI: https://pypi.org/project/robotframework-falsegreen/)
- Docs: https://vinicq.github.io/falsegreen-docs/

Single additive line, appended to the bottom of the category per CONTRIBUTING.md. Description follows the existing one-line format.