### PR TITLE
Add crosslocator library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The Robot Framework Foundation is a non-profit organization that supports the de
 - [ADB Library](https://github.com/ganesanluna/ADBLibrary) Library that provides Android Debug Bridge (ADB) functionalities for automated testing and device control.
 - [Android Library](https://github.com/lovelysystems/robotframework-androidlibrary) ([Keywords](http://www.lovelysystems.com/robotframework-androidlibrary/AndroidLibrary.html)) Library for all your Android automation needs. It uses Calabash Android internally.
 - [Appium Library](https://github.com/serhatbolsu/robotframework-appiumlibrary) Library for Android- and iOS-testing. It uses Appium internally.
-- [crosslocator](https://github.com/julien-becheny/crosslocator) Define a UI selector once, resolve it per platform (Android, iOS, iPadOS, Windows). Framework-agnostic, with AppiumLibrary keywords.
+- [crosslocator](https://github.com/julien-becheny/crosslocator) Define a UI selector once and resolve it per platform (Android, iOS, iPadOS, Windows). Framework-agnostic, with Robot Framework keywords (`Set Current Platform`, `Resolve Locator`).
 - [iOS Library](https://github.com/lovelysystems/robotframework-ioslibrary) Library for all your iOS automation needs. It uses Calabash iOS Server internally.
 
 ### Cloud and Devops

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The Robot Framework Foundation is a non-profit organization that supports the de
 - [ADB Library](https://github.com/ganesanluna/ADBLibrary) Library that provides Android Debug Bridge (ADB) functionalities for automated testing and device control.
 - [Android Library](https://github.com/lovelysystems/robotframework-androidlibrary) ([Keywords](http://www.lovelysystems.com/robotframework-androidlibrary/AndroidLibrary.html)) Library for all your Android automation needs. It uses Calabash Android internally.
 - [Appium Library](https://github.com/serhatbolsu/robotframework-appiumlibrary) Library for Android- and iOS-testing. It uses Appium internally.
+- [crosslocator](https://github.com/julien-becheny/crosslocator) Define a UI selector once, resolve it per platform (Android, iOS, iPadOS, Windows). Framework-agnostic, with AppiumLibrary keywords.
 - [iOS Library](https://github.com/lovelysystems/robotframework-ioslibrary) Library for all your iOS automation needs. It uses Calabash iOS Server internally.
 
 ### Cloud and Devops


### PR DESCRIPTION
I released a small, dependency-free library for a recurring pain in cross-platform mobile testing: maintaining the same locator for Android, iOS, iPadOS and Windows.

You define a selector once per platform, and crosslocator resolves the right one at runtime:

    from crosslocator import Locator

    LOGIN = Locator(
        android="accessibility_id=login",
        ios="accessibility_id=login",
        windows='//Button[@Name="Log in"]',
        default="id=login",
    )
    LOGIN.resolve()  # the right selector for the current platform

It works with pure Python (Appium) and Robot Framework (a small library exposing `Set Current Platform` / `Resolve Locator` keywords). It can also auto-detect the platform from the active Appium session. iPad falls back to iOS selectors, and a shared default covers the rest.

- Install: pip install crosslocator
- Source: https://github.com/julien-becheny/crosslocator

It's an early release (v0.2). Feedback and issues are very welcome — especially on the Robot Framework integration and the locator formats you'd like supported.