### PR TITLE
Add Agent QA to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ The Robot Framework Foundation is a non-profit organization that supports the de
 - [Robot-Framework-AI-Agent-Datadriver](https://github.com/jg8481/Robot-Framework-AI-Agent-Datadriver) - AI agent project that combines the capabilities of Codename Goose, MCP tools, the Robot Framework ecosystem, decentralized LLMs on Ollama, and Docker.
 - [Result Companion](https://github.com/miltroj/result-companion) - AI-powered Robot Framework debugger — pinpoints why tests failed and how to fix them directly in log.html; supports custom analysis prompts and 100+ LLM providers.
 - [robotframework-agentskills](https://github.com/manykarim/robotframework-agentskills) - Modular skills and agents for AI coding assistants (Claude Code, Copilot, Cursor, etc.) to write, debug, and migrate Robot Framework tests, with an MCP server and multi-agent installer.
+- [Agent QA](https://github.com/vostride/agent-qa) - Independent natural-language web/mobile QA agent with persistent memory, self-healing, MCP, and Agent Skills; useful alongside Robot Framework rather than as a Robot Framework library.
 
 ### Execution Tools
 


### PR DESCRIPTION
## Summary

Adds [Agent QA](https://github.com/vostride/agent-qa) to the bottom of **Tools → AI Tools**.

The description deliberately identifies Agent QA as an independent companion for natural-language web/mobile QA, not a Robot Framework library or integration. Its persistent memory, self-healing, MCP server, and Agent Skills can complement a Robot Framework testing stack without implying interoperability that the project does not publish.

## Contribution checks

- one suggestion in this PR
- useful title and commit message; commit body links the submitted repository
- appended to the bottom of the relevant category
- succinct `[Name](link) - Description.` entry
- no duplicate Agent QA entry
- `git diff --check`

Repository-wide `npx --yes awesome-lint` reports 13 existing badge/duplicate-link diagnostics; the new Agent QA line is absent from those diagnostics.
